### PR TITLE
Added support for the "exists" method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ print_r($bucket->respondsTo());
 #     [15] => bucketVersioning
 #     [16] => bucketWebsite
 #     [17] => object
+#     [18] => exists
 # )
 ```
 
@@ -221,7 +222,6 @@ There is still a lot of work to do on the AWS Resources API for PHP. Here are
 some things we have on the list to work on soon.
 
 1. Support for batch actions on Batch and Collection objects (e.g., `$messages->delete();`)
-1. Support for waiters on resources (e.g., `$instance->waitUntil('Running');`)
 1. Support for more AWS services
 1. API documentation for the AWS Resource APIs
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -68,6 +68,9 @@ class Model
             foreach ($items as $item) {
                 if ($key === 'waiters') {
                     $methods["waitUntil{$item}"] = $key;
+                    if ($item === 'Exists') {
+                        $methods['exists'] = 'exists';
+                    }
                 } else {
                     $methods[lcfirst($item)] = $key;
                 }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -191,6 +191,8 @@ class Resource implements \IteratorAggregate, \ArrayAccess
                 return $this->client->performAction($name, $args, $this);
             case 'waiters':
                 return $this->client->waitUntil(substr($name, 9), $args, $this);
+            case 'exists':
+                return $this->client->checkIfExists($this);
             default:
                 throw new \BadMethodCallException(
                     "You cannot call {$name} on the {$this->type} resource."

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -100,6 +100,7 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
                  'performAction',
                  'makeCollection',
                  'waitUntil',
+                 'checkIfExists',
             ])
             ->getMock();
         $rc->expects($this->once())->method('getMetaData')->willReturn([
@@ -112,12 +113,14 @@ class ResourceTest extends \PHPUnit_Framework_TestCase
                 'b' => 'related',
                 'c' => 'collections',
                 'd' => 'waiters',
+                'e' => 'exists',
             ]
         ]);
         $rc->expects($this->once())->method('makeRelated');
         $rc->expects($this->once())->method('performAction');
         $rc->expects($this->once())->method('makeCollection');
         $rc->expects($this->once())->method('waitUntil');
+        $rc->expects($this->once())->method('checkIfExists');
 
         $resource = new Resource($rc, 'Thing', []);
         foreach ($resource->respondsTo() as $property) {


### PR DESCRIPTION
For resources that have a waiter named "Exists", you can call the `$resource->exists()` method, which will return true if the resource exists, or false if it does not.

CR please: @mtdowling @jeskew
